### PR TITLE
Fixes for Coq 8.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.vo
+*.vok
+*.vos
 *.v.d
 *.glob
 *.aux
@@ -15,3 +17,6 @@
 Makefile.coq
 .coqdeps.d
 Makefile.coq.conf
+.coqdeps.d
+*.Makefile.coq.d
+*.lia.cache

--- a/AssociationList.v
+++ b/AssociationList.v
@@ -409,15 +409,15 @@ Proof.
   destruct (in_deq Key _ a0 vs);
   subst; cpx; split; introns Hyp; allsimpl; exrepnd; cpx.
   - dec. dorn Hyp; cpx; cpx. apply IHsub in Hyp.
-    exrepnd.
-    apply in_remove in Hyp; cpx.
+    exrepnd. 
+    eapply list.in_remove in Hyp; cpx.
   - dec. cpx.
      apply IHsub in Hyp; exrepnd; cpx.
   - dorn Hyp; cpx. apply IHsub in Hyp.
     exrepnd.
-    apply in_remove in Hyp; cpx.
+    apply list.in_remove in Hyp; cpx.
   - right. apply IHsub; dands; cpx.
-    apply in_remove; dands; cpx.
+    apply list.in_remove; dands; cpx.
 Qed.
 
 Lemma ALKeepFirstLinApp:

--- a/alphaeq.v
+++ b/alphaeq.v
@@ -1901,7 +1901,7 @@ Proof using.
   destruct subr as [ |(vr,tr) subr]; try invertsn Hsr.
   - repeat (apply ex_intro with ( x:=nil)); dands; spc. apply binrel_list_nil.
   - repnd. apply Hind in Hsr. exrepnd.
-    exists (vr::lv), (tl::lntl), (tr::lntr).
+    exists (vr::lv); exists (tl::lntl); exists (tr::lntr).
     allsimpl. dands; f_equal; spc.
     apply binrel_list_cons; spc.
 Qed.

--- a/list.v
+++ b/list.v
@@ -2304,7 +2304,7 @@ Global Instance decideDisjoint {T:Type} {deqt: Deq T} (la lb: list T)
   : Decidable (disjoint la lb).
 exists (decide_disjoint la lb).
   rewrite <- decide_disjoint_correct.
-  destruct (dec_disjoint deqt la lb); simpl; firstorder.
+  destruct (dec_disjoint deqt la lb); simpl; firstorder auto with *.
 Defined.
 
 Ltac simpl_list :=
@@ -3794,12 +3794,13 @@ Lemma RlistNth {A B:Type} (R: A-> B-> Prop) (la : list A) (lb : list B):
 Proof using.
   revert lb.
   induction la; intros lb; split; intros Hyp; destruct lb as [ | b lb]; simpl in *;
-    dlists_len;  try firstorder; try f_equal; try constructor; try firstorder;
+    dlists_len;  try firstorder auto with *; try f_equal; try constructor; try firstorder auto with *;
       rename H0 into Hyps0.
 - specialize (IHla lb).  rewrite IHla in Hyps0.
   apply proj2 in Hyps0.
   destruct n; eauto.
   apply Hyps0. omega.
+- exact nil.
 - specialize (Hyps0 0). simpl in *. apply Hyps0; eauto. omega.
 - apply IHla. dands; auto. intros. specialize (Hyps0 (S n)). simpl in *.
   apply Hyps0. omega.

--- a/substitution.v
+++ b/substitution.v
@@ -674,8 +674,8 @@ Lemma in_sub_free_vars :
 Proof using.
   induction sub; simpl; sp; allsimpl.
   allrw in_app_iff; sp.
-  exists a0,a; sp. apply IHsub in H. sp.
-  exists x,t; sp.
+  exists a0. exists a; sp. apply IHsub in H. sp.
+  exists x. exists t; sp.
 Qed.
 
 Lemma in_sub_free_vars_iff :
@@ -688,9 +688,9 @@ Proof using.
   split; sp.
   rw in_app_iff.
   rw IHsub; split; sp; inj; sp.
-  exists a0,a; sp.
-  exists x,t; sp.
-  right; exists x,t; sp.
+  exists a0. exists a; sp.
+  exists x. exists t; sp.
+  right; exists x; exists t; sp.
 Qed.
 
 Lemma subset_free_vars_mem :
@@ -3493,10 +3493,10 @@ Proof using. nterm_ind1 nt as [vn | o lbt Hind] Case; introv Hdis Hin.
       subst;simpl in Hin;
       ((rw <- beq_var_refl in Hin;auto)
           || (rw not_eq_beq_var_false in Hin;auto)).
-      + right. exists vs,ts. sp; auto.
-      + cases (sub_find sub vn) as Hf.
+      + right. exists vs. exists ts. sp; auto.
+      + cases (sub_find sub vn) as Hf. 
           * applydup @sub_find_some in Hf.
-             right; exists vn,n; split; auto. right;auto. simpl. split; auto.
+             right; exists vn. exists n; split; auto. right;auto. simpl. split; auto.
           * left; auto.
   - Case "oterm".
     simpl in Hin. rw lin_flat_map in Hin.
@@ -4040,7 +4040,7 @@ Proof using.
       allrw @in_sub_filter; sp.
       allrw in_sub_keep_first; sp.
       right.
-      exists x0,t; sp.
+      exists x0. exists t; sp.
       allrw in_sub_keep_first; sp.
       rw lin_flat_map.
       exists (bterm l n); simpl; sp.
@@ -4092,7 +4092,7 @@ Proof using.
       rw Hg.
       rw in_app_iff.
       rw @in_sub_free_vars_iff; right.
-      exists x0,t; sp.
+      exists x0. exists t; sp.
       rw in_sub_keep_first; sp.
       rw sub_find_sub_filter_some; sp.
       applydup @sub_find_some in H3.
@@ -5043,7 +5043,7 @@ Proof using.
   apply NTerm_BTerm_ind.
   - simpl. intros v ? Hin. right. 
     dsub_find sn; cpx;[].
-    exists v,sns. split; auto.
+    exists v. exists sns. split; auto.
 
   - simpl. intros _ ? Hind ? Hin.
     rewrite flat_map_map in Hin. 
@@ -5716,10 +5716,10 @@ Proof using. nterm_ind1 nt as [vn | o lbt Hind] Case; introv Hin.
       subst;simpl in Hin;
       ((rw <- beq_var_refl in Hin;auto) 
           || (rw not_eq_beq_var_false in Hin;auto)).
-      + right. exists vs,ts. sp; auto.
+      + right. exists vs; exists ts. sp; auto.
       + cases (sub_find sub vn) as Hf.
           * applydup @sub_find_some in Hf.
-             right; exists vn,n; split; auto. right;auto. simpl. split; auto.
+             right; exists vn; exists n; split; auto. right;auto. simpl. split; auto.
           * left;split;auto. allsimpl;subst. introv Hc. dorn Hc; subst; sp.
             subst. apply sub_find_none2 in Hf. sp.
   - Case "oterm".
@@ -6042,7 +6042,7 @@ Proof using.
     rw @memvar_dmemvar. rw @memvar_dmemvar. 
     apply binrel_list_cons in Hl1. repnd. duplicate Hl0.
     cases_ifd Ha; eapply Hind with (lnta := lnta) in Hl0 ; eauto;[].
-    exrepnd. exists (v::lvi'), (ha :: lnta'), (hb :: lntb').
+    exrepnd. exists (v::lvi'); exists (ha :: lnta'); exists (hb :: lntb').
     allsimpl. dands; spc; try (f_equal;spc).
     apply binrel_list_cons; sp.
 Qed.


### PR DESCRIPTION
Here's a version compiling under Coq 8.12. I'm marking it as draft for now because I first want to ensure that all of CertiCoq compiles.

The only notable fix for 8.12 was that the syntax `exists x1, x2.` in Ltac scripts is broken, maybe because of a conflicting notation on terms. Instead I used `exists x1; exists x2` everywhere.